### PR TITLE
Add user-input VELLANO net profit calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Codex-deneme
+
+This repository contains sample scripts. Use `vellano_kar_hesapla.py` to calculate the net profit for selling VELLANO bags. The script asks for basic inputs like sale price, cost, shipping, advertising, payment commission and monthly sales volume, then prints the net profit per item and total monthly profit.

--- a/vellano_kar_hesapla.py
+++ b/vellano_kar_hesapla.py
@@ -1,0 +1,44 @@
+# Python script to calculate net profit for VELLANO bag sales based on user input
+
+
+def vellano_kar_hesapla(
+    satis_fiyati_usd,
+    urun_maliyeti_usd,
+    kargo_ucreti_usd,
+    reklam_cpa_usd,
+    odeme_komisyonu_oran,
+    aylik_satis_adedi,
+):
+    """Satış başına ve aylık net kârı hesapla ve yazdır."""
+    toplam_gider = (
+        urun_maliyeti_usd
+        + kargo_ucreti_usd
+        + reklam_cpa_usd
+        + (satis_fiyati_usd * odeme_komisyonu_oran)
+    )
+    net_kar = satis_fiyati_usd - toplam_gider
+    aylik_net_kar = net_kar * aylik_satis_adedi
+
+    print(f"Ürün başı net kâr: ${net_kar:.2f}")
+    print(f"Aylık {aylik_satis_adedi} satış ile toplam net kâr: ${aylik_net_kar:.2f}")
+
+
+if __name__ == "__main__":
+    try:
+        satis_fiyati_usd = float(input("Satış fiyatı (USD): "))
+        urun_maliyeti_usd = float(input("Ürün maliyeti (USD): "))
+        kargo_ucreti_usd = float(input("Kargo ücreti (USD): "))
+        reklam_cpa_usd = float(input("Reklam CPA (USD): "))
+        odeme_komisyonu_oran = float(input("Ödeme komisyon oranı (ör. 0.035): "))
+        aylik_satis_adedi = int(input("Aylık satış adedi: "))
+    except ValueError:
+        print("Lütfen geçerli bir sayı girin.")
+    else:
+        vellano_kar_hesapla(
+            satis_fiyati_usd,
+            urun_maliyeti_usd,
+            kargo_ucreti_usd,
+            reklam_cpa_usd,
+            odeme_komisyonu_oran,
+            aylik_satis_adedi,
+        )


### PR DESCRIPTION
## Summary
- add `vellano_kar_hesapla.py` for calculating profit per sale and monthly profit
- update README with instructions for the new script

## Testing
- `python3 vellano_kar_hesapla.py <<EOF
399
80
20
70
0.035
100
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6883f1b79238832092c02bcbdd490928